### PR TITLE
Add error range to results

### DIFF
--- a/src/process-replies.js
+++ b/src/process-replies.js
@@ -14,7 +14,9 @@ function mapToValues(answers) {
   return answers.map(value => valueMap[value]);
 }
 
-export function match(answers, matchersAnswers) {
+// minMax === false => minimal possible score
+// minMax === true => maximal possible score
+export function match(answers, matchersAnswers, minMax) {
   if (!matchersAnswers) {
     return 0;
   }
@@ -28,6 +30,12 @@ export function match(answers, matchersAnswers) {
     if (my != null && them != null) {
       distance += Math.abs(my - them);
       ranks += 1;
+    } else if (my != null && minMax === false) {
+      distance += Math.max(Math.abs(my - -1), Math.abs(my - 1));
+      ranks += 1;
+    } else if (my != null && minMax === true) {
+      distance += Math.min(Math.abs(my - -1), Math.abs(my - 1));
+      ranks += 1;
     }
   });
 
@@ -40,7 +48,9 @@ export default function getResultsByScore(answers, dataset) {
   const answerValues = mapToValues(answers);
   const data = dataset.map(data => ({
     ...data,
-    score: match(answerValues, data.reply && mapToValues(data.reply.split(''))),
+    score: match(answerValues, data.reply && mapToValues(data.reply.split('')), null),
+    minScore: match(answerValues, data.reply && mapToValues(data.reply.split('')), false),
+    maxScore: match(answerValues, data.reply && mapToValues(data.reply.split('')), true),
   }));
   // Ignore NaN scores
   const filteredData = _.filter(data, 'score');

--- a/src/routes/questionnaire-results/KosningaProfResults.js
+++ b/src/routes/questionnaire-results/KosningaProfResults.js
@@ -198,6 +198,14 @@ class KosningaprofResults extends PureComponent {
                 <div className={s.partyName}>{party.name}</div>
                 <div className={s.partyPercentage}>
                   {Math.ceil(party.score)}%
+                  {(Math.ceil(party.score) != Math.ceil(party.minScore) || Math.ceil(party.score) != Math.ceil(party.maxScore)) ?
+                      ' (' +
+                        Math.ceil(party.minScore) + '-' +
+                        Math.ceil(party.maxScore) + '%' +
+                      ')'
+                    :
+                      ''
+                  }
                 </div>
               </div>
               <Collapse


### PR DESCRIPTION
I wanted to add error bars to results for cases when parties have not responded to all questions. But it turns out only one current party has not (Povezimo Slovenijo), so this is pretty limited in usefulness. Still, I am making a PR because it maybe will be useful at some point.

Currently it just shows a range next to the percentage, but it does not change how the progress bar is visualized. Maybe somebody else wants to tackle that.

Probably I have to update some tests as well, because `getResultsByScore` is not returning more data.

I have not committed `build` so that it is easier to merge this PR. After merging it should be rebuild.

TODO:
* Update tests.
* Add some message next to results explaining what this range is, if any such range is shown (that the party didn't respond to everything, so there is a possible range of the match).